### PR TITLE
Fix powsybl-network-viewer submodule name and repository link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -353,9 +353,9 @@
 	url = https://github.com/powsybl/powsybl-diagram
 	branch = main
 	ignore = all
-[submodule "powsybl-diagram-viewer"]
-	path = frontend/libs/powsybl-diagram-viewer
-	url = https://github.com/powsybl/powsybl-diagram-viewer
+[submodule "powsybl-network-viewer"]
+	path = frontend/libs/powsybl-network-viewer
+	url = https://github.com/powsybl/powsybl-network-viewer
 	branch = main
 	ignore = all
 [submodule "powsybl-network-store-server"]


### PR DESCRIPTION
fix(): powsybl-network-viewer submodule has changed, then point to the correct repository